### PR TITLE
Fix build errors and add type packages

### DIFF
--- a/About.tsx
+++ b/About.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Card } from './ui/Card';
-import { Button } from './ui/Button';
+import { Card } from './Card';
+import { Button } from './Button';
 
 interface ServiceCardProps {
     icon: string;

--- a/AdminDashboard.tsx
+++ b/AdminDashboard.tsx
@@ -1,13 +1,13 @@
 import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react';
-import { getReferrals, getReferrers, updateReferralStatus, getBookingRequests, updateBookingRequestStatus } from '../services/api';
-import { Referral, Referrer, ReferralStatus, BadgeTier, BookingRequest, BookingStatus } from '../types';
-import { BADGE_THRESHOLDS } from '../constants';
-import { Card } from './ui/Card';
-import { Badge } from './ui/Badge';
-import { Button } from './ui/Button';
-import { UserIcon } from './icons/UserIcon';
-import { CalendarIcon } from './icons/CalendarIcon';
-import { PhoneIcon } from './icons/PhoneIcon';
+import { getReferrals, getReferrers, updateReferralStatus, getBookingRequests, updateBookingRequestStatus } from './api';
+import { Referral, Referrer, ReferralStatus, BadgeTier, BookingRequest, BookingStatus } from './types';
+import { BADGE_THRESHOLDS } from './constants';
+import { Card } from './Card';
+import { Badge } from './Badge';
+import { Button } from './Button';
+import { UserIcon } from './UserIcon';
+import { CalendarIcon } from './CalendarIcon';
+import { PhoneIcon } from './PhoneIcon';
 
 const getBadgeTier = (count: number): BadgeTier => {
   if (count >= BADGE_THRESHOLDS.Platinum) return BadgeTier.Platinum;

--- a/App.tsx
+++ b/App.tsx
@@ -1,13 +1,13 @@
 
 import React, { useState, useEffect } from 'react';
 import { HashRouter, Routes, Route, Navigate } from 'react-router-dom';
-import { Header } from './components/Header';
-import { Footer } from './components/Footer';
-import { ReferralForm } from './components/ReferralForm';
-import { About } from './components/About';
-import { Booking } from './components/Booking';
-import { Login } from './components/Login';
-import { AdminDashboard } from './components/AdminDashboard';
+import { Header } from './Header';
+import { Footer } from './Footer';
+import { ReferralForm } from './ReferralForm';
+import { About } from './About';
+import { Booking } from './Booking';
+import { Login } from './Login';
+import { AdminDashboard } from './AdminDashboard';
 import { auth } from './firebase';
 import { User } from 'firebase/auth';
 

--- a/Badge.tsx
+++ b/Badge.tsx
@@ -1,7 +1,7 @@
 
 import React from 'react';
-import { BadgeTier } from '../../types';
-import { BADGE_STYLES } from '../../constants';
+import { BadgeTier } from './types';
+import { BADGE_STYLES } from './constants';
 
 interface BadgeProps {
   tier: BadgeTier;

--- a/Booking.tsx
+++ b/Booking.tsx
@@ -1,19 +1,12 @@
-import React, { useState, useMemo, useEffect, useRef } from 'react';
-// Like in the Login component, `useActionState` and `useFormStatus` are
-// experimental hooks provided by the `react-dom` package rather than `react`.
-// Importing them from `react` leads to undefined values during runtime.
-// Import `useFormStatus` for potential future use, though we no longer rely on
-// `useActionState`.  Keeping `useFormStatus` here in case you wish to
-// implement custom pending indicators at the field level.
-import { useFormStatus } from 'react-dom';
+import React, { useState, useMemo, useRef } from 'react';
 import ReCAPTCHA from 'react-google-recaptcha';
-import { Card } from './ui/Card';
-import { Button } from './ui/Button';
-import { Input } from './ui/Input';
-import { submitBookingRequest } from '../services/api';
-import { UserIcon } from './icons/UserIcon';
-import { PhoneIcon } from './icons/PhoneIcon';
-import { RECAPTCHA_SITE_KEY } from '../config';
+import { Card } from './Card';
+import { Button } from './Button';
+import { Input } from './Input';
+import { submitBookingRequest } from './api';
+import { UserIcon } from './UserIcon';
+import { PhoneIcon } from './PhoneIcon';
+import { RECAPTCHA_SITE_KEY } from './config';
 
 // Helper function to get the next 5 weekdays
 const getNextWeekdays = () => {
@@ -38,15 +31,6 @@ const getNextWeekdays = () => {
     return days;
 };
 
-type FormState = {
-  error: string | null;
-  isSuccess: boolean;
-};
-
-const initialState: FormState = {
-  error: null,
-  isSuccess: false,
-};
 
 // Render a submit button with explicit loading state.  Using our own loading
 // indicator avoids reliance on the experimental `useActionState` hook.

--- a/Header.tsx
+++ b/Header.tsx
@@ -1,9 +1,9 @@
 import React, { useState, useEffect } from 'react';
 import { NavLink, useNavigate } from 'react-router-dom';
-import { Button } from './ui/Button';
-import { MenuIcon } from './icons/MenuIcon';
-import { XIcon } from './icons/XIcon';
-import { auth } from '../firebase';
+import { Button } from './Button';
+import { MenuIcon } from './MenuIcon';
+import { XIcon } from './XIcon';
+import { auth } from './firebase';
 
 interface HeaderProps {
   isLoggedIn: boolean;

--- a/Login.tsx
+++ b/Login.tsx
@@ -9,12 +9,12 @@ import React, { useState } from 'react';
 // implement our own loading and error handling within the component.
 import { useNavigate } from 'react-router-dom';
 import ReCAPTCHA from 'react-google-recaptcha';
-import { Card } from './ui/Card';
-import { Input } from './ui/Input';
-import { Button } from './ui/Button';
-import { auth } from '../firebase';
+import { Card } from './Card';
+import { Input } from './Input';
+import { Button } from './Button';
+import { auth } from './firebase';
 import { signInWithEmailAndPassword } from 'firebase/auth';
-import { RECAPTCHA_SITE_KEY } from '../config';
+import { RECAPTCHA_SITE_KEY } from './config';
 
 // Simple Mail Icon
 const MailIcon: React.FC<{className?: string}> = ({className}) => (

--- a/ReferralForm.tsx
+++ b/ReferralForm.tsx
@@ -1,12 +1,12 @@
 import React, { useState, useRef } from 'react';
 import ReCAPTCHA from 'react-google-recaptcha';
-import { Card } from './ui/Card';
-import { Input } from './ui/Input';
-import { Button } from './ui/Button';
-import { submitReferral } from '../services/api';
-import { UserIcon } from './icons/UserIcon';
-import { CalendarIcon } from './icons/CalendarIcon';
-import { RECAPTCHA_SITE_KEY } from '../config';
+import { Card } from './Card';
+import { Input } from './Input';
+import { Button } from './Button';
+import { submitReferral } from './api';
+import { UserIcon } from './UserIcon';
+import { CalendarIcon } from './CalendarIcon';
+import { RECAPTCHA_SITE_KEY } from './config';
 
 /**
  * A form that allows users to recommend a new contact. This component uses

--- a/firebase.ts
+++ b/firebase.ts
@@ -6,7 +6,7 @@ import { getFirestore, serverTimestamp, Firestore } from 'firebase/firestore';
 import { initializeAppCheck, ReCaptchaV3Provider, AppCheck } from 'firebase/app-check';
 
 // Import application configuration constants
-import { APP_CHECK_SITE_KEY } from '../config';
+import { APP_CHECK_SITE_KEY } from './config';
 
 /**
  * Firebase configuration for this project. These values are specific to your

--- a/package.json
+++ b/package.json
@@ -9,14 +9,17 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "firebase": "10.12.3",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-router-dom": "6.24.1",
     "react-google-recaptcha": "3.1.0",
-    "firebase": "10.12.3"
+    "react-router-dom": "6.24.1"
   },
   "devDependencies": {
     "@types/node": "^22.14.0",
+    "@types/react": "^19.1.8",
+    "@types/react-dom": "^19.1.6",
+    "@types/react-google-recaptcha": "^2.1.9",
     "typescript": "~5.7.2",
     "vite": "^6.2.0"
   }


### PR DESCRIPTION
## Summary
- remove unused hooks and state from booking form
- update Firestore helpers to use query snapshots
- improve referral update transaction logic
- install React type packages

## Testing
- `npx tsc --noEmit`
- `npm run build`
- `npm run dev` *(terminated after startup)*


------
https://chatgpt.com/codex/tasks/task_e_688628758ca88326a5926b6364bf8291