### PR TITLE
Add Node entry point for Vite app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+.dist
+*.log
+npm-debug.log*
+dist
+
+

--- a/index.js
+++ b/index.js
@@ -1,0 +1,16 @@
+import { createServer } from 'vite';
+
+const port = process.env.PORT || 8080;
+
+createServer({
+  server: {
+    port: Number(port),
+    host: true,
+  },
+}).then((server) => {
+  server.listen();
+  console.log(`Vite dev server running on port ${port}`);
+}).catch((err) => {
+  console.error('Failed to start Vite dev server:', err);
+  process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "start": "node index.js"
   },
   "dependencies": {
     "firebase": "10.12.3",


### PR DESCRIPTION
## Summary
- add Node server entry that starts Vite dev server
- wire up `npm start` to run the new entry
- ignore build output and node modules

## Testing
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_68867133746c8326b3e970c592619e5f