### PR TITLE
Add simple server entrypoint

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,14 @@
+import { createServer } from 'vite';
+
+const port = parseInt(process.env.PORT || '8080', 10);
+
+createServer()
+  .then(server => {
+    return server.listen(port).then(() => {
+      console.log(`Vite dev server running on port ${port}`);
+    });
+  })
+  .catch(err => {
+    console.error('Failed to start Vite dev server:', err);
+    process.exit(1);
+  });

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "start": "node index.js"
   },
   "dependencies": {
     "firebase": "10.12.3",


### PR DESCRIPTION
## Summary
- add `index.js` server entrypoint that starts Vite dev server
- expose `npm start` script for container startup

## Testing
- `npm install`
- `node index.js` (prints `Vite dev server running on port 8080`)

------
https://chatgpt.com/codex/tasks/task_e_68867133746c8326b3e970c592619e5f